### PR TITLE
Fixture in recursive acontextmanager

### DIFF
--- a/pytest_trio/_tests/test_sync_fixture.py
+++ b/pytest_trio/_tests/test_sync_fixture.py
@@ -44,3 +44,46 @@ def test_single_yield_fixture(testdir):
     result = testdir.runpytest()
 
     result.assert_outcomes(passed=3)
+
+
+def test_single_yield_fixture_with_async_deps(testdir):
+
+    testdir.makepyfile(
+        """
+        import pytest
+        import trio
+
+        events = []
+
+        @pytest.fixture
+        async def fix0():
+            events.append('fix0 setup')
+            await trio.sleep(0)
+            return 'fix0'
+
+        @pytest.fixture
+        def fix1(fix0):
+            events.append('fix1 setup')
+            yield 'fix1 - ' + fix0
+            events.append('fix1 teardown')
+
+        def test_before():
+            assert not events
+
+        @pytest.mark.trio
+        async def test_actual_test(fix1):
+            assert events == ['fix0 setup', 'fix1 setup']
+            assert fix1 == 'fix1 - fix0'
+
+        def test_after():
+            assert events == [
+                'fix0 setup',
+                'fix1 setup',
+                'fix1 teardown',
+            ]
+    """
+    )
+
+    result = testdir.runpytest()
+
+    result.assert_outcomes(passed=3)


### PR DESCRIPTION
Trying to implement a solution to https://github.com/python-trio/pytest-trio/issues/25#issuecomment-352990630

The code is python 3.6 only so far, but it would be trivial to use `async_generator` to make it work for python 3.5 too