### PR TITLE
Add test_async_yield_fixture_crashed_teardown_allow_other_teardowns

### DIFF
--- a/pytest_trio/_tests/test_async_yield_fixture.py
+++ b/pytest_trio/_tests/test_async_yield_fixture.py
@@ -261,3 +261,51 @@ def test_async_yield_fixture_with_nursery(testdir):
     result = testdir.runpytest()
 
     result.assert_outcomes(passed=1)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6")
+def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
+
+    testdir.makepyfile(
+        """
+        import pytest
+        import trio
+
+        events = []
+
+        @pytest.fixture
+        async def good_fixture():
+            async with trio.open_nursery() as nursery:
+                events.append('good_fixture setup')
+                yield
+                events.append('good_fixture teardown')
+
+        @pytest.fixture
+        async def bad_fixture():
+            async with trio.open_nursery() as nursery:
+                events.append('bad_fixture setup')
+                yield
+                events.append('bad_fixture teardown')
+                raise RuntimeError('Crash during fixture teardown')
+                # Cannot cancel offtask's scope
+
+        def test_before():
+            assert not events
+
+        @pytest.mark.trio
+        async def test_actual_test(bad_fixture, good_fixture):
+            pass
+
+        def test_after():
+            assert events == [
+                'good_fixture setup',
+                'bad_fixture setup',
+                'bad_fixture teardown',
+            ]
+    """
+    )
+
+    result = testdir.runpytest()
+
+    result.assert_outcomes(failed=1, passed=2)
+    result.stdout.re_match_lines('E       RuntimeError: Crash during fixture teardown')

--- a/pytest_trio/_tests/test_async_yield_fixture.py
+++ b/pytest_trio/_tests/test_async_yield_fixture.py
@@ -287,7 +287,6 @@ def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
                 yield
                 events.append('bad_fixture teardown')
                 raise RuntimeError('Crash during fixture teardown')
-                # Cannot cancel offtask's scope
 
         def test_before():
             assert not events
@@ -301,6 +300,7 @@ def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
                 'good_fixture setup',
                 'bad_fixture setup',
                 'bad_fixture teardown',
+                'good_fixture teardown',
             ]
     """
     )
@@ -308,4 +308,4 @@ def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
     result = testdir.runpytest()
 
     result.assert_outcomes(failed=1, passed=2)
-    result.stdout.re_match_lines('E       RuntimeError: Crash during fixture teardown')
+    result.stdout.re_match_lines([r'E\W+RuntimeError: Crash during fixture teardown'])

--- a/pytest_trio/_tests/test_async_yield_fixture.py
+++ b/pytest_trio/_tests/test_async_yield_fixture.py
@@ -308,4 +308,6 @@ def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
     result = testdir.runpytest()
 
     result.assert_outcomes(failed=1, passed=2)
-    result.stdout.re_match_lines([r'E\W+RuntimeError: Crash during fixture teardown'])
+    result.stdout.re_match_lines(
+        [r'E\W+RuntimeError: Crash during fixture teardown']
+    )

--- a/pytest_trio/_tests/test_sync_fixture.py
+++ b/pytest_trio/_tests/test_sync_fixture.py
@@ -135,4 +135,6 @@ def test_sync_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
     result = testdir.runpytest()
 
     result.assert_outcomes(failed=1, passed=2)
-    result.stdout.re_match_lines([r'E\W+RuntimeError: Crash during fixture teardown'])
+    result.stdout.re_match_lines(
+        [r'E\W+RuntimeError: Crash during fixture teardown']
+    )

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -134,14 +134,15 @@ class AsyncYieldFixture(BaseAsyncFixture):
         __tracebackhide__ = True
         agen = self.fixturedef.func(**resolved_deps)
 
-        await yield_(await agen.asend(None))
-
         try:
-            await agen.asend(None)
-        except StopAsyncIteration:
-            pass
-        else:
-            raise RuntimeError('Only one yield in fixture is allowed')
+            await yield_(await agen.asend(None))
+        finally:
+            try:
+                await agen.asend(None)
+            except StopAsyncIteration:
+                pass
+            else:
+                raise RuntimeError('Only one yield in fixture is allowed')
 
 
 class SyncFixtureWithAsyncDeps(BaseAsyncFixture):
@@ -167,14 +168,15 @@ class SyncYieldFixtureWithAsyncDeps(BaseAsyncFixture):
         __tracebackhide__ = True
         gen = self.fixturedef.func(**resolved_deps)
 
-        await yield_(gen.send(None))
-
         try:
-            gen.send(None)
-        except StopIteration:
-            pass
-        else:
-            raise RuntimeError('Only one yield in fixture is allowed')
+            await yield_(gen.send(None))
+        finally:
+            try:
+                gen.send(None)
+            except StopIteration:
+                pass
+            else:
+                raise RuntimeError('Only one yield in fixture is allowed')
 
 
 class AsyncFixture(BaseAsyncFixture):

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -1,19 +1,23 @@
 """pytest-trio implementation."""
+import sys
 from traceback import format_exception
 from inspect import iscoroutinefunction, isgeneratorfunction
-try:
-    from inspect import isasyncgenfunction
-except ImportError:
-    # `inspect.isasyncgenfunction` not available with Python<3.6
-    def isasyncgenfunction(x):
-        return False
-
-
 import pytest
 import trio
 from trio._util import acontextmanager
 from trio.testing import MockClock, trio_test
 from async_generator import async_generator, yield_
+
+if sys.version_info >= (3, 6):
+    from inspect import isasyncgenfunction
+    ORDERED_DICTS = True
+else:
+    # `inspect.isasyncgenfunction` not available with Python<3.6
+    def isasyncgenfunction(x):
+        return False
+
+    # Ordered dict (and **kwargs) not available with Python<3.6
+    ORDERED_DICTS = False
 
 
 def pytest_configure(config):
@@ -69,6 +73,9 @@ async def _setup_async_fixtures_in(deps):
     need_resolved_deps_stack = [
         (k, v) for k, v in deps.items() if isinstance(v, BaseAsyncFixture)
     ]
+    if not ORDERED_DICTS:
+        # Make the fixture resolution order determinist
+        need_resolved_deps_stack = sorted(need_resolved_deps_stack)
 
     if not need_resolved_deps_stack:
         await yield_(deps)


### PR DESCRIPTION
I've found a bug when using multiple async context managers containing nurseries and one of them crash during it teardown. In such case it seems the nursery in the crashed fixture is not properly destroyed, hence a trio internal error occurs when the pytest-trio main nursery is closed.

So far this PR only contains a test to reproduce the bug.

@njsmith I couldn't go futher in the track of the bug, I would suspect the pytest-trio code responsible for [catching the fixture exceptions](https://github.com/python-trio/pytest-trio/blob/92649135cfa0b4a5232da4012851b4370b45feca/pytest_trio/plugin.py#L46), but more because it feels hacky than because I have proofs :smile: 