### PR TITLE
Use async_generator's isasyncgenfunction

### DIFF
--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -2,12 +2,9 @@
 from traceback import format_exception
 from inspect import iscoroutinefunction, isgeneratorfunction
 try:
-    from inspect import isasyncgenfunction
+    from async_generator import isasyncgenfunction
 except ImportError:
-    # `inspect.isasyncgenfunction` not available with Python<3.6
-    def isasyncgenfunction(x):
-        return False
-
+    from inspect import isasyncgenfunction
 
 import pytest
 import trio


### PR DESCRIPTION
This patch adds Python 3.5 compatibility for async fixtures.