### PR TITLE
Bumpversion 0.4.0 -> 0.4.1

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,12 @@ Release history
 
 .. towncrier release notes start
 
+Pytest_Trio 0.4.1 (2018-04-14)
+------------------------------
+
+No significant changes.
+
+
 Pytest_Trio 0.4.0 (2018-04-14)
 ------------------------------
 

--- a/pytest_trio/_version.py
+++ b/pytest_trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.3.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
(forgot to update `pytest_trio/_version.py` in version 0.4.0 :disappointed: )