### PR TITLE
Support Trio testing with Hypothesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/newsfragments/42.feature.rst
+++ b/newsfragments/42.feature.rst
@@ -1,0 +1,2 @@
+pytest-trio now integrates with `Hypothesis <https://hypothesis.readthedocs.io>`_
+to support ``@given`` on async tests using Trio.

--- a/pytest_trio/_tests/test_hypothesis_interaction.py
+++ b/pytest_trio/_tests/test_hypothesis_interaction.py
@@ -1,0 +1,22 @@
+import pytest
+from hypothesis import given, strategies as st
+
+
+@given(st.integers())
+@pytest.mark.trio
+async def test_mark_inner(n):
+    assert isinstance(n, int)
+
+
+@pytest.mark.trio
+@given(st.integers())
+async def test_mark_outer(n):
+    assert isinstance(n, int)
+
+
+@pytest.mark.parametrize('y', [1, 2])
+@given(x=st.none())
+@pytest.mark.trio
+async def test_mark_and_parametrize(x, y):
+    assert x is None
+    assert y in (1, 2)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+hypothesis>=3.64


### PR DESCRIPTION
Closes #42, based on my work upstream in HypothesisWorks/hypothesis#1343.

CC @njsmith and @zmitchell - note that you'll need a recent version of Hypothesis as the mechanism to support this was literally released yesterday!  It's public API and perfectly stable though, agreeing on a design we liked enough to support long-term is the main thing that took us so long :smile: 