### PR TITLE
Rework fixtures

### DIFF
--- a/ci/rtd-requirements.txt
+++ b/ci/rtd-requirements.txt
@@ -2,3 +2,6 @@
 sphinx >= 1.6.1
 sphinx_rtd_theme
 sphinxcontrib-trio
+# Workaround for this weird issue:
+# https://travis-ci.org/python-trio/pytest-trio/jobs/407495415
+attrs >= 17.4.0

--- a/pytest_trio/__init__.py
+++ b/pytest_trio/__init__.py
@@ -1,3 +1,6 @@
 """Top-level package for pytest-trio."""
 
 from ._version import __version__
+from .plugin import trio_fixture
+
+__all__ = ["trio_fixture"]

--- a/pytest_trio/_tests/helpers.py
+++ b/pytest_trio/_tests/helpers.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def enable_trio_mode_via_pytest_ini(testdir):
+    testdir.makefile(".ini", pytest="[pytest]\ntrio_mode = true\n")
+
+
+def enable_trio_mode_via_conftest_py(testdir):
+    testdir.makeconftest("from pytest_trio.enable_trio_mode import *")
+
+
+enable_trio_mode = pytest.mark.parametrize(
+    "enable_trio_mode",
+    [enable_trio_mode_via_pytest_ini, enable_trio_mode_via_conftest_py]
+)

--- a/pytest_trio/_tests/test_basic.py
+++ b/pytest_trio/_tests/test_basic.py
@@ -21,7 +21,7 @@ def test_async_test_is_executed(testdir):
     """
     )
 
-    result = testdir.runpytest()
+    result = testdir.runpytest("-s")
 
     result.assert_outcomes(passed=2)
 

--- a/pytest_trio/_tests/test_contextvars.py
+++ b/pytest_trio/_tests/test_contextvars.py
@@ -1,0 +1,37 @@
+import pytest
+from pytest_trio import trio_fixture
+
+import contextvars
+
+cv = contextvars.ContextVar("cv", default=None)
+
+
+@trio_fixture
+def cv_checker():
+    assert cv.get() is None
+    yield
+    assert cv.get() is None
+
+
+@trio_fixture
+def cv_setter(cv_checker):
+    assert cv.get() is None
+    token = cv.set("cv_setter")
+    yield
+    assert cv.get() == "cv_setter2"
+    cv.reset(token)
+    assert cv.get() is None
+
+
+@trio_fixture
+def cv_setter2(cv_setter):
+    assert cv.get() == "cv_setter"
+    # Intentionally leak, so can check that this is visible back in cv_setter
+    cv.set("cv_setter2")
+    yield
+    assert cv.get() == "cv_setter2"
+
+
+@pytest.mark.trio
+async def test_contextvars(cv_setter2):
+    assert cv.get() == "cv_setter2"

--- a/pytest_trio/_tests/test_fixture_mistakes.py
+++ b/pytest_trio/_tests/test_fixture_mistakes.py
@@ -1,0 +1,68 @@
+import pytest
+from pytest_trio import trio_fixture
+
+
+def test_trio_fixture_with_non_trio_test(testdir):
+    testdir.makepyfile(
+        """
+        import trio
+        from pytest_trio import trio_fixture
+        import pytest
+
+        @trio_fixture
+        def trio_time():
+            return trio.current_time()
+
+        @pytest.fixture
+        def indirect_trio_time(trio_time):
+            return trio_time + 1
+
+        @pytest.mark.trio
+        async def test_async(mock_clock, trio_time, indirect_trio_time):
+            assert trio_time == 0
+            assert indirect_trio_time == 1
+
+        def test_sync(trio_time):
+            pass
+
+        def test_sync_indirect(indirect_trio_time):
+            pass
+        """
+    )
+
+    result = testdir.runpytest()
+
+    result.assert_outcomes(passed=1, error=2)
+    result.stdout.fnmatch_lines(
+        ["*Trio fixtures can only be used by Trio tests*"]
+    )
+
+
+def test_trio_fixture_with_wrong_scope(testdir):
+    # There's a trick here: when you have a non-function-scope fixture, it's
+    # not instantiated for any particular function (obviously). So... when our
+    # pytest_fixture_setup hook tries to check for marks, it can't normally
+    # see @pytest.mark.trio. So... it's actually almost impossible to have an
+    # async fixture get treated as a Trio fixture *and* have it be
+    # non-function-scope. But, class-scoped fixtures can see marks on the
+    # class, so this is one way (the only way?) it can happen:
+    testdir.makepyfile(
+        """
+        import pytest
+        import pytest_trio
+
+        @pytest.fixture(scope="class")
+        async def async_class_fixture():
+            pass
+
+        @pytest.mark.trio
+        class TestFoo:
+            async def test_foo(self, async_class_fixture):
+                pass
+        """
+    )
+
+    result = testdir.runpytest()
+
+    result.assert_outcomes(error=1)
+    result.stdout.fnmatch_lines(["*must be function-scope*"])

--- a/pytest_trio/_tests/test_fixture_names.py
+++ b/pytest_trio/_tests/test_fixture_names.py
@@ -1,0 +1,18 @@
+import pytest
+from pytest_trio import trio_fixture
+import trio
+
+
+@trio_fixture
+def fixture_with_unique_name(nursery):
+    nursery.start_soon(trio.sleep_forever)
+
+
+@pytest.mark.trio
+async def test_fixture_names(fixture_with_unique_name):
+    # This might be a bit fragile ... if we rearrange the nursery hierarchy
+    # somehow so it breaks, then we can make it more robust.
+    task = trio.hazmat.current_task()
+    assert task.name == "<test 'test_fixture_names'>"
+    sibling_names = {task.name for task in task.parent_nursery.child_tasks}
+    assert "<fixture 'fixture_with_unique_name'>" in sibling_names

--- a/pytest_trio/_tests/test_fixture_nursery.py
+++ b/pytest_trio/_tests/test_fixture_nursery.py
@@ -9,8 +9,8 @@ async def handle_client(stream):
 
 
 @pytest.fixture
-async def server(test_nursery):
-    listeners = await test_nursery.start(trio.serve_tcp, handle_client, 0)
+async def server(fixture_nursery):
+    listeners = await fixture_nursery.start(trio.serve_tcp, handle_client, 0)
     return listeners[0]
 
 

--- a/pytest_trio/_tests/test_fixture_nursery.py
+++ b/pytest_trio/_tests/test_fixture_nursery.py
@@ -9,8 +9,8 @@ async def handle_client(stream):
 
 
 @pytest.fixture
-async def server(fixture_nursery):
-    listeners = await fixture_nursery.start(trio.serve_tcp, handle_client, 0)
+async def server(nursery):
+    listeners = await nursery.start(trio.serve_tcp, handle_client, 0)
     return listeners[0]
 
 

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -1,0 +1,284 @@
+import pytest
+
+# Tests that:
+# - leaf_fix gets set up first and torn down last
+# - the two fix_concurrent_{1,2} fixtures run their setup/teardown code
+#   at the same time -- their execution can be interleaved.
+def test_fixture_basic_ordering(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        from pytest_trio import trio_fixture
+        from trio.testing import Sequencer
+        from async_generator import async_generator, yield_
+
+        setup_events = []
+        teardown_events = []
+
+        @trio_fixture
+        def seq():
+            return Sequencer()
+
+        @pytest.fixture
+        @async_generator
+        async def leaf_fix():
+            setup_events.append("leaf_fix setup")
+            await yield_()
+            teardown_events.append("leaf_fix teardown")
+
+            assert teardown_events == [
+                "fix_concurrent_1 teardown 1",
+                "fix_concurrent_2 teardown 1",
+                "fix_concurrent_1 teardown 2",
+                "fix_concurrent_2 teardown 2",
+                "leaf_fix teardown",
+            ]
+
+        @pytest.fixture
+        @async_generator
+        async def fix_concurrent_1(leaf_fix, seq):
+            async with seq(0):
+                setup_events.append("fix_concurrent_1 setup 1")
+            async with seq(2):
+                setup_events.append("fix_concurrent_1 setup 2")
+            await yield_()
+            async with seq(4):
+                teardown_events.append("fix_concurrent_1 teardown 1")
+            async with seq(6):
+                teardown_events.append("fix_concurrent_1 teardown 2")
+
+        @pytest.fixture
+        @async_generator
+        async def fix_concurrent_2(leaf_fix, seq):
+            async with seq(1):
+                setup_events.append("fix_concurrent_2 setup 1")
+            async with seq(3):
+                setup_events.append("fix_concurrent_2 setup 2")
+            await yield_()
+            async with seq(5):
+                teardown_events.append("fix_concurrent_2 teardown 1")
+            async with seq(7):
+                teardown_events.append("fix_concurrent_2 teardown 2")
+
+        @pytest.mark.trio
+        async def test_root(fix_concurrent_1, fix_concurrent_2):
+            assert setup_events == [
+                "leaf_fix setup",
+                "fix_concurrent_1 setup 1",
+                "fix_concurrent_2 setup 1",
+                "fix_concurrent_1 setup 2",
+                "fix_concurrent_2 setup 2",
+            ]
+            assert teardown_events == []
+
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_nursery_fixture_teardown_ordering(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        from pytest_trio import trio_fixture
+        import trio
+        from trio.testing import wait_all_tasks_blocked
+
+        events = []
+
+        async def record_cancel(msg):
+            try:
+                await trio.sleep_forever()
+            finally:
+                events.append(msg)
+
+        @pytest.fixture
+        def fix0():
+            yield
+            assert events == [
+                "test",
+                "test cancel",
+                "fix2 teardown",
+                "fix2 cancel",
+                "fix1 teardown",
+                "fix1 cancel",
+            ]
+
+        @trio_fixture
+        def fix1(nursery):
+            nursery.start_soon(record_cancel, "fix1 cancel")
+            yield
+            events.append("fix1 teardown")
+
+        @trio_fixture
+        def fix2(fix1, nursery):
+            nursery.start_soon(record_cancel, "fix2 cancel")
+            yield
+            events.append("fix2 teardown")
+
+        @pytest.mark.trio
+        async def test_root(fix2, nursery):
+            nursery.start_soon(record_cancel, "test cancel")
+            await wait_all_tasks_blocked()
+            events.append("test")
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_error_collection(testdir):
+    # We want to make sure that pytest ultimately reports all the different
+    # exceptions. We call .upper() on all the exceptions so that we have
+    # tokens to look for in the output corresponding to each exception, where
+    # those tokens don't appear at all the source (so we can't get a false
+    # positive due to pytest printing out the source file).
+
+    # We sleep at the beginning of all the fixtures b/c currently if any
+    # fixture crashes, we skip setting up unrelated fixtures whose setup
+    # hasn't even started yet. Maybe we shouldn't? But for now the sleeps make
+    # sure that all the fixtures have started before any of them start
+    # crashing.
+    testdir.makepyfile(
+        """
+        import pytest
+        from pytest_trio import trio_fixture
+        import trio
+        from async_generator import async_generator, yield_
+
+        test_started = False
+
+        @trio_fixture
+        async def crash_nongen():
+            await trio.sleep(2)
+            raise RuntimeError("crash_nongen".upper())
+
+        @trio_fixture
+        @async_generator
+        async def crash_early_agen():
+            await trio.sleep(2)
+            raise RuntimeError("crash_early_agen".upper())
+            await yield_()
+
+        @trio_fixture
+        @async_generator
+        async def crash_late_agen():
+            await yield_()
+            raise RuntimeError("crash_late_agen".upper())
+
+        async def crash(when, token):
+            with trio.open_cancel_scope(shield=True):
+                await trio.sleep(when)
+                raise RuntimeError(token.upper())
+
+        @trio_fixture
+        def crash_background(nursery):
+            nursery.start_soon(crash, 1, "crash_background_early")
+            nursery.start_soon(crash, 3, "crash_background_late")
+
+        @pytest.mark.trio
+        async def test_all_the_crashes(
+            autojump_clock,
+            crash_nongen, crash_early_agen, crash_late_agen, crash_background,
+        ):
+            global test_started
+            test_started = True
+
+        def test_followup():
+            assert not test_started
+
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    result.stdout.fnmatch_lines_random([
+        "*CRASH_NONGEN*",
+        "*CRASH_EARLY_AGEN*",
+        "*CRASH_LATE_AGEN*",
+        "*CRASH_BACKGROUND_EARLY*",
+        "*CRASH_BACKGROUND_LATE*",
+    ])
+
+
+@pytest.mark.parametrize("bgmode", ["nursery fixture", "manual nursery"])
+def test_background_crash_cancellation_propagation(bgmode, testdir):
+    crashyfix_using_nursery_fixture = """
+        @trio_fixture
+        def crashyfix(nursery):
+            nursery.start_soon(crashy)
+            yield
+            # We should be cancelled here
+            teardown_deadlines["crashyfix"] = trio.current_effective_deadline()
+        """
+
+    crashyfix_using_manual_nursery = """
+        @trio_fixture
+        @async_generator
+        async def crashyfix():
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(crashy)
+                await yield_()
+                # We should be cancelled here
+                teardown_deadlines["crashyfix"] = trio.current_effective_deadline()
+        """
+
+    if bgmode == "nursery fixture":
+        crashyfix = crashyfix_using_nursery_fixture
+    else:
+        crashyfix = crashyfix_using_manual_nursery
+
+    testdir.makepyfile(
+        """
+        import pytest
+        from pytest_trio import trio_fixture
+        import trio
+        from async_generator import async_generator, yield_
+
+        teardown_deadlines = {}
+        final_time = None
+
+        async def crashy():
+            await trio.sleep(1)
+            raise RuntimeError
+
+        CRASHYFIX_HERE
+
+        @trio_fixture
+        def sidefix():
+            yield
+            # We should NOT be cancelled here
+            teardown_deadlines["sidefix"] = trio.current_effective_deadline()
+
+        @trio_fixture
+        def userfix(crashyfix):
+            yield
+            # Currently we should NOT be cancelled here... though maybe this
+            # should change?
+            teardown_deadlines["userfix"] = trio.current_effective_deadline()
+
+        @pytest.mark.trio
+        async def test_it(userfix, sidefix, autojump_clock):
+            try:
+                await trio.sleep_forever()
+            finally:
+                global final_time
+                final_time = trio.current_time()
+
+
+        def test_post():
+            assert teardown_deadlines == {
+                "crashyfix": -float("inf"),
+                "sidefix": float("inf"),
+                "userfix": float("inf"),
+            }
+            assert final_time == 1
+        """
+        .replace("CRASHYFIX_HERE", crashyfix)
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=1)

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 # Tests that:
 # - leaf_fix gets set up first and torn down last
 # - the two fix_concurrent_{1,2} fixtures run their setup/teardown code
@@ -195,13 +196,15 @@ def test_error_collection(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(passed=1, failed=1)
-    result.stdout.fnmatch_lines_random([
-        "*CRASH_NONGEN*",
-        "*CRASH_EARLY_AGEN*",
-        "*CRASH_LATE_AGEN*",
-        "*CRASH_BACKGROUND_EARLY*",
-        "*CRASH_BACKGROUND_LATE*",
-    ])
+    result.stdout.fnmatch_lines_random(
+        [
+            "*CRASH_NONGEN*",
+            "*CRASH_EARLY_AGEN*",
+            "*CRASH_LATE_AGEN*",
+            "*CRASH_BACKGROUND_EARLY*",
+            "*CRASH_BACKGROUND_LATE*",
+        ]
+    )
 
 
 @pytest.mark.parametrize("bgmode", ["nursery fixture", "manual nursery"])
@@ -276,8 +279,7 @@ def test_background_crash_cancellation_propagation(bgmode, testdir):
                 "userfix": float("inf"),
             }
             assert final_time == 1
-        """
-        .replace("CRASHYFIX_HERE", crashyfix)
+        """.replace("CRASHYFIX_HERE", crashyfix)
     )
 
     result = testdir.runpytest()

--- a/pytest_trio/_tests/test_nursery_fixture.py
+++ b/pytest_trio/_tests/test_nursery_fixture.py
@@ -9,8 +9,8 @@ async def handle_client(stream):
 
 
 @pytest.fixture
-async def server(nursery):
-    listeners = await nursery.start(trio.serve_tcp, handle_client, 0)
+async def server(test_nursery):
+    listeners = await test_nursery.start(trio.serve_tcp, handle_client, 0)
     return listeners[0]
 
 

--- a/pytest_trio/_tests/test_trio_asyncio.py
+++ b/pytest_trio/_tests/test_trio_asyncio.py
@@ -1,7 +1,15 @@
 import pytest
-import trio_asyncio
+import sys
 import asyncio
 from async_generator import async_generator, yield_
+
+if sys.version_info < (3, 6):
+    pytestmark = pytest.mark.skip(
+        reason="trio-asyncio doesn't seem to work on 3.5"
+    )
+else:
+    import trio_asyncio
+
 
 @trio_asyncio.trio2aio
 async def work_in_asyncio():

--- a/pytest_trio/_tests/test_trio_asyncio.py
+++ b/pytest_trio/_tests/test_trio_asyncio.py
@@ -1,0 +1,43 @@
+import pytest
+import trio_asyncio
+import asyncio
+
+
+@trio_asyncio.trio2aio
+async def work_in_asyncio():
+    await asyncio.sleep(0)
+
+
+@pytest.fixture()
+async def asyncio_loop():
+    async with trio_asyncio.open_loop() as loop:
+        yield loop
+
+
+@pytest.fixture()
+async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
+    await work_in_asyncio()
+    yield 42
+
+
+@pytest.fixture()
+async def asyncio_fixture_own_loop():
+    async with trio_asyncio.open_loop():
+        await work_in_asyncio()
+        yield 42
+
+
+@pytest.mark.trio
+async def test_no_fixture():
+    async with trio_asyncio.open_loop():
+        await work_in_asyncio()
+
+
+@pytest.mark.trio
+async def test_half_fixtured_asyncpg_conn(asyncio_fixture_own_loop):
+    await work_in_asyncio()
+
+
+@pytest.mark.trio
+async def test_fixtured_asyncpg_conn(asyncio_fixture_with_fixtured_loop):
+    await work_in_asyncio()

--- a/pytest_trio/_tests/test_trio_asyncio.py
+++ b/pytest_trio/_tests/test_trio_asyncio.py
@@ -1,7 +1,7 @@
 import pytest
 import trio_asyncio
 import asyncio
-
+from async_generator import async_generator, yield_
 
 @trio_asyncio.trio2aio
 async def work_in_asyncio():
@@ -9,22 +9,25 @@ async def work_in_asyncio():
 
 
 @pytest.fixture()
+@async_generator
 async def asyncio_loop():
     async with trio_asyncio.open_loop() as loop:
-        yield loop
+        await yield_(loop)
 
 
 @pytest.fixture()
+@async_generator
 async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
     await work_in_asyncio()
-    yield 42
+    await yield_()
 
 
 @pytest.fixture()
+@async_generator
 async def asyncio_fixture_own_loop():
     async with trio_asyncio.open_loop():
         await work_in_asyncio()
-        yield 42
+        await yield_()
 
 
 @pytest.mark.trio

--- a/pytest_trio/_tests/test_trio_asyncio.py
+++ b/pytest_trio/_tests/test_trio_asyncio.py
@@ -11,9 +11,8 @@ else:
     import trio_asyncio
 
 
-@trio_asyncio.trio2aio
-async def work_in_asyncio():
-    await asyncio.sleep(0)
+async def use_run_asyncio():
+    await trio_asyncio.run_asyncio(asyncio.sleep, 0)
 
 
 @pytest.fixture()
@@ -26,7 +25,7 @@ async def asyncio_loop():
 @pytest.fixture()
 @async_generator
 async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
-    await work_in_asyncio()
+    await use_run_asyncio()
     await yield_()
 
 
@@ -34,21 +33,21 @@ async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
 @async_generator
 async def asyncio_fixture_own_loop():
     async with trio_asyncio.open_loop():
-        await work_in_asyncio()
+        await use_run_asyncio()
         await yield_()
 
 
 @pytest.mark.trio
 async def test_no_fixture():
     async with trio_asyncio.open_loop():
-        await work_in_asyncio()
+        await use_run_asyncio()
 
 
 @pytest.mark.trio
 async def test_half_fixtured_asyncpg_conn(asyncio_fixture_own_loop):
-    await work_in_asyncio()
+    await use_run_asyncio()
 
 
 @pytest.mark.trio
 async def test_fixtured_asyncpg_conn(asyncio_fixture_with_fixtured_loop):
-    await work_in_asyncio()
+    await use_run_asyncio()

--- a/pytest_trio/_tests/test_trio_mode.py
+++ b/pytest_trio/_tests/test_trio_mode.py
@@ -1,5 +1,7 @@
 import pytest
 
+from .helpers import enable_trio_mode
+
 test_text = """
 import pytest
 import trio
@@ -26,19 +28,11 @@ async def test_hypothesis_fail(b):
 """
 
 
-def test_trio_mode_pytest_ini(testdir):
+@enable_trio_mode
+def test_trio_mode(testdir, enable_trio_mode):
+    enable_trio_mode(testdir)
+
     testdir.makepyfile(test_text)
-
-    testdir.makefile(".ini", pytest="[pytest]\ntrio_mode = true\n")
-
-    result = testdir.runpytest()
-    result.assert_outcomes(passed=2, failed=2)
-
-
-def test_trio_mode_conftest(testdir):
-    testdir.makepyfile(test_text)
-
-    testdir.makeconftest("from pytest_trio.enable_trio_mode import *")
 
     result = testdir.runpytest()
     result.assert_outcomes(passed=2, failed=2)

--- a/pytest_trio/enable_trio_mode.py
+++ b/pytest_trio/enable_trio_mode.py
@@ -1,7 +1,11 @@
-__all__ = ["pytest_collection_modifyitems"]
+__all__ = ["pytest_collection_modifyitems", "pytest_fixture_setup"]
 
-from .plugin import automark
+from .plugin import automark, handle_fixture
 
 
 def pytest_collection_modifyitems(items):
     automark(items)
+
+
+def pytest_fixture_setup(fixturedef, request):
+    return handle_fixture(fixturedef, request, force_trio_mode=True)

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -275,5 +275,16 @@ def autojump_clock():
 
 
 @trio_fixture
-def nursery(request):
+def test_nursery(request):
     return request.node._trio_nursery
+
+
+@trio_fixture
+def nursery(test_nursery):
+    import warnings
+    warnings.warn(
+        FutureWarning(
+            "The 'nursery' fixture has been renamed to 'test_nursery'"
+        )
+    )
+    return test_nursery

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -173,7 +173,6 @@ class TrioFixture:
                 finally:
                     fixture_nursery.cancel_scope.cancel()
         except BaseException as exc:
-            print(repr(exc))
             ctx.crash(exc)
         finally:
             self.setup_done.set()
@@ -314,8 +313,6 @@ def _trio_test_runner_factory(item, testfunc=None):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    print(item)
-    print(item.get_closest_marker("trio"))
     if item.get_closest_marker("trio") is not None:
         if hasattr(item.obj, 'hypothesis'):
             # If it's a Hypothesis test, we go in a layer.

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -110,6 +110,7 @@ def pytest_exception_interact(node, call, report):
 # follow the normal teardown sequence, and so on – but since the test is
 # cancelled, the teardown sequence should start immediately.
 
+
 class TrioTestContext:
     def __init__(self):
         self.crashed = False
@@ -356,7 +357,10 @@ def handle_fixture(fixturedef, request, force_trio_mode):
     else:
         is_trio_mode = request.node.config.getini("trio_mode")
     coerce_async = (is_trio_test or is_trio_mode)
-    kwargs = {name: request.getfixturevalue(name) for name in fixturedef.argnames}
+    kwargs = {
+        name: request.getfixturevalue(name)
+        for name in fixturedef.argnames
+    }
     if _is_trio_fixture(fixturedef.func, coerce_async, kwargs):
         if request.scope != "function":
             raise RuntimeError("Trio fixtures must be function-scope")

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
     install_requires=[
         "trio",
         "async_generator >= 1.9",
+        # For node.get_closest_marker
+        "pytest >= 3.6"
     ],
     keywords=[
         'async',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-pytest
+pytest !=3.7.0, !=3.7.1  # https://github.com/python-trio/pytest-trio/pull/50#issuecomment-413124393
 pytest-cov
 hypothesis>=3.64

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest !=3.7.0, !=3.7.1  # https://github.com/python-trio/pytest-trio/pull/50#issuecomment-413124393
 pytest-cov
 hypothesis>=3.64
+trio-asyncio


### PR DESCRIPTION
- Add @pytest_trio.trio_fixture for explicitly marking a fixture as
  being a trio fixture
- Make the nursery fixture a @trio_fixture
- Refactor Trio fixture classes into one class
- Check for trio marker instead of trio keyword (fixes gh-43)
  - This also raises the minimum pytest version to 3.6
- Raise an error if a Trio fixture is used with a non-function
  scope (fixes gh-18)
- Raise an error if a Trio fixture is used with a non-Trio test

I think this also closes gh-10's discussion, though we still need to
convince pytest-asyncio to fix their side of things.