### PR TITLE
Fix compatibility with pytest 3.8.1

### DIFF
--- a/newsfragments/64.bugfix.rst
+++ b/newsfragments/64.bugfix.rst
@@ -1,0 +1,2 @@
+The pytest 3.8.1 release broke pytest-trio's handling of trio tests
+defined as class methods. We fixed it again.

--- a/pytest_trio/_tests/conftest.py
+++ b/pytest_trio/_tests/conftest.py
@@ -3,7 +3,8 @@
 import pytest
 import warnings
 warnings.filterwarnings(
-    "default", category=pytest.RemovedInPytest4Warning,
+    "default",
+    category=pytest.RemovedInPytest4Warning,
     message=".*non-top-level conftest.*",
 )
 

--- a/pytest_trio/_tests/conftest.py
+++ b/pytest_trio/_tests/conftest.py
@@ -1,1 +1,10 @@
+# Temporary hack while waiting for an answer here:
+#    https://github.com/pytest-dev/pytest/issues/4039
+import pytest
+import warnings
+warnings.filterwarnings(
+    "default", category=pytest.RemovedInPytest4Warning,
+    message=".*non-top-level conftest.*",
+)
+
 pytest_plugins = ["pytester"]

--- a/pytest_trio/_tests/test_trio_asyncio.py
+++ b/pytest_trio/_tests/test_trio_asyncio.py
@@ -9,8 +9,8 @@ except ImportError:
     pytestmark = pytest.mark.skip(reason="trio-asyncio not available")
 
 
-async def use_run_asyncio():
-    await trio_asyncio.run_asyncio(asyncio.sleep, 0)
+async def use_asyncio():
+    await trio_asyncio.aio_as_trio(asyncio.sleep)(0)
 
 
 @pytest.fixture()
@@ -23,7 +23,7 @@ async def asyncio_loop():
 @pytest.fixture()
 @async_generator
 async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
-    await use_run_asyncio()
+    await use_asyncio()
     await yield_()
 
 
@@ -31,21 +31,21 @@ async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
 @async_generator
 async def asyncio_fixture_own_loop():
     async with trio_asyncio.open_loop():
-        await use_run_asyncio()
+        await use_asyncio()
         await yield_()
 
 
 @pytest.mark.trio
 async def test_no_fixture():
     async with trio_asyncio.open_loop():
-        await use_run_asyncio()
+        await use_asyncio()
 
 
 @pytest.mark.trio
 async def test_half_fixtured_asyncpg_conn(asyncio_fixture_own_loop):
-    await use_run_asyncio()
+    await use_asyncio()
 
 
 @pytest.mark.trio
 async def test_fixtured_asyncpg_conn(asyncio_fixture_with_fixtured_loop):
-    await use_run_asyncio()
+    await use_asyncio()

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -292,7 +292,7 @@ class TrioFixture:
 
 
 def _trio_test_runner_factory(item, testfunc=None):
-    testfunc = testfunc or item.function
+    testfunc = testfunc or item.obj
 
     if getattr(testfunc, '_trio_test_runner_wrapped', False):
         # We have already wrapped this, perhaps because we combined Hypothesis


### PR DESCRIPTION
Apparently for a test *method*, item.obj and item.function are
different: item.obj is the bound method, and item.function is the
underlying unbound method. At least in pytest 3.8.1.

We want to wrap the bound method, not the unbound method, so we should
wrap item.obj, not item.function.

Fixes #64 