### PR TITLE
Add Hypothesis trove classifier for pytest-trio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Networking",
         "Topic :: Software Development :: Testing",
+        "Framework :: Hypothesis",
         "Framework :: Pytest",
         "Framework :: Trio",
     ],


### PR DESCRIPTION
Since PR #44, `pytest-trio` has had special handling that allows `@hypothesis.given(...)` for Trio tests even though they are async functions.  This PR is a trivial update to add the new `Framework :: Hypothesis` trove classifier (:tada:), as discussed in HypothesisWorks/hypothesis#1663, so that users can more easily tell from the metadata.