### PR TITLE
Fix a bug that AttributeError is raised when it's run with pytest-flake8

### DIFF
--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -411,10 +411,14 @@ def pytest_fixture_setup(fixturedef, request):
 
 def automark(items):
     for item in items:
-        if hasattr(item.obj, "hypothesis"):
-            test_func = item.obj.hypothesis.inner_test
+        try:
+            obj = item.obj
+        except AttributeError:
+            continue
+        if hasattr(obj, "hypothesis"):
+            test_func = obj.hypothesis.inner_test
         else:
-            test_func = item.obj
+            test_func = obj
         if iscoroutinefunction(test_func):
             item.add_marker(pytest.mark.trio)
 


### PR DESCRIPTION
Because [pytest-flake8]'s `Flake8Item` has no `obj` attribute, `automark()` raises `AttributeError` when it's run with pytest-flake8.  This fixes `automark()` to test first if an item has its `obj` attribute.

[pytest-flake8]: https://github.com/tholo/pytest-flake8