### PR TITLE
Move pytest options to pytest inifile

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -92,7 +92,7 @@ else
     mkdir empty
     cd empty
 
-    coverage run --rcfile=../.coveragerc -m pytest -W error -ra -v --pyargs pytest_trio --verbose
+    pytest
 
     bash <(curl -s https://codecov.io/bash)
 fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -W error -ra -v --pyargs pytest_trio --verbose --cov


### PR DESCRIPTION
A naive `pytest` run currently fails with the following trace:
```console
$ pytest
==================================== test session starts =====================================
platform linux -- Python 3.7.2, pytest-4.1.0, py-1.7.0, pluggy-0.8.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/vinmic/pytest-trio/.hypothesis/examples')
rootdir: /home/vinmic/pytest-trio, inifile:
plugins: xdist-1.25.0, trio-0.5.1, forked-0.2, cov-2.6.1, hypothesis-3.88.3
collected 0 items / 1 errors                                                                 

=========================================== ERRORS ===========================================
_____________________________________ ERROR collecting  ______________________________________
../miniconda/lib/python3.7/site-packages/_pytest/config/__init__.py:427: in _importconftest
    return self._conftestpath2mod[conftestpath]
E   KeyError: local('/home/vinmic/pytest-trio/pytest_trio/_tests/conftest.py')

During handling of the above exception, another exception occurred:
../miniconda/lib/python3.7/site-packages/_pytest/config/__init__.py:433: in _importconftest
    mod = conftestpath.pyimport()
../miniconda/lib/python3.7/site-packages/py/_path/local.py:688: in pyimport
    raise self.ImportMismatchError(modname, modfile, self)
E   py._path.local.LocalPath.ImportMismatchError: ('pytest_trio._tests.conftest', '/home/vinmic/miniconda/lib/python3.7/site-packages/pytest_trio/_tests/conftest.py', local('/home/vinmic/pytest-trio/pytest_trio/_tests/conftest.py'))

During handling of the above exception, another exception occurred:
../miniconda/lib/python3.7/site-packages/py/_path/common.py:377: in visit
    for x in Visitor(fil, rec, ignore, bf, sort).gen(self):
../miniconda/lib/python3.7/site-packages/py/_path/common.py:429: in gen
    for p in self.gen(subdir):
../miniconda/lib/python3.7/site-packages/py/_path/common.py:418: in gen
    dirs = self.optsort([p for p in entries
../miniconda/lib/python3.7/site-packages/py/_path/common.py:419: in <listcomp>
    if p.check(dir=1) and (rec is None or rec(p))])
../miniconda/lib/python3.7/site-packages/_pytest/main.py:635: in _recurse
    ihook = self.gethookproxy(dirpath)
../miniconda/lib/python3.7/site-packages/_pytest/main.py:452: in gethookproxy
    my_conftestmodules = pm._getconftestmodules(fspath)
../miniconda/lib/python3.7/site-packages/_pytest/config/__init__.py:411: in _getconftestmodules
    mod = self._importconftest(conftestpath)
../miniconda/lib/python3.7/site-packages/_pytest/config/__init__.py:450: in _importconftest
    raise ConftestImportFailure(conftestpath, sys.exc_info())
E   _pytest.config.ConftestImportFailure: (local('/home/vinmic/pytest-trio/pytest_trio/_tests/conftest.py'), (<class 'py._path.local.LocalPath.ImportMismatchError'>, ImportMismatchError('pytest_trio._tests.conftest', '/home/vinmic/miniconda/lib/python3.7/site-packages/pytest_trio/_tests/conftest.py', local('/home/vinmic/pytest-trio/pytest_trio/_tests/conftest.py')), <traceback object at 0x7fc3575b6b08>))
!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!
================================== 1 error in 0.16 seconds ===================================
```

This PR moves the pytest options defined in `ci/travis.sh` to a pytest inifile. I had to create a new `pytest.ini` file since `pyproject.toml` isn't [supported by pytest yet](https://github.com/pytest-dev/pytest/issues/1556). This shouldn't break the CI (hopefully). 