### PR TITLE
Fix exception swallow in fixture due to parent cancel scope

### DIFF
--- a/pytest_trio/_tests/test_async_yield_fixture.py
+++ b/pytest_trio/_tests/test_async_yield_fixture.py
@@ -366,7 +366,9 @@ def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(
     )
 
 
-def test_async_yield_fixture_crashed_then_parent_cancel(testdir, async_yield_implementation):
+def test_async_yield_fixture_crashed_then_parent_cancel(
+        testdir, async_yield_implementation
+):
     testdir.makepyfile(
         async_yield_implementation(
             """

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -354,7 +354,7 @@ def _trio_test_runner_factory(item, testfunc=None):
 
         if test_ctx.error_list:
             raise trio.MultiError(test_ctx.error_list)
-        elif test_ctx.crashed:
+        elif test_ctx.crashed:  # pragma: no cover
             raise trio.TrioInternalError(
                 "Test has crashed, but we couldn't recover the error "
                 "(see https://github.com/python-trio/pytest-trio/issues/75)"


### PR DESCRIPTION
Following #75, I've finally isolated the original issue:

```python
async def die_soon(*, task_status=trio.TASK_STATUS_IGNORED):
    task_status.started()
    raise RuntimeError('Ooops !')

@asynccontextmanager
async def async_finalizer():
    try:
        yield
    finally:
        await trio.sleep(0)

@pytest.fixture
async def fixture(nursery):
    async with trio.open_nursery() as nursery1:
        async with async_finalizer():
            async with trio.open_nursery() as nursery2:
                await nursery2.start(die_soon)
                yield
                # Comment next line to make the test pass :'(
                nursery1.cancel_scope.cancel()

@pytest.mark.trio
async def test_try(fixture):
    await trio.sleep_forever()
```

1) `die_soon` causes the fixture to crash
2) Because how pytest-trio works, the information that `die_soon` has crashed doesn't make yield to return with an exception
3) Hence `nursery1` is cancelled
4) any async teardown operation  in `async_finalizer` end up with a Cancelled exception
5) this Cancelled exception reach the `nursery1`'s which conclude no other exceptions has occurred

The sad part is if we convert the fixture into a regular async context manager, everything works fine.

I'm not really sure how we could fix that (well I'm not even sure about the steps I've listed :smile: ), @njsmith any idea ?
