### PR TITLE
Rework handling of cancelled 'yield' in fixtures

### DIFF
--- a/newsfragments/75.feature.rst
+++ b/newsfragments/75.feature.rst
@@ -1,4 +1,6 @@
 Incompatible change: if you use ``yield`` inside a Trio fixture, and
 the ``yield`` gets cancelled (for example, due to a background task
 crashing), then the ``yield`` will now raise :exc:`trio.Cancelled`.
-See :ref:`cancel-yield` for details.
+See :ref:`cancel-yield` for details. Also, in this same case,
+pytest-trio will now reliably mark the test as failed, even if the
+fixture doesn't go on to raise an exception.

--- a/newsfragments/75.feature.rst
+++ b/newsfragments/75.feature.rst
@@ -1,0 +1,4 @@
+Incompatible change: if you use ``yield`` inside a Trio fixture, and
+the ``yield`` gets cancelled (for example, due to a background task
+crashing), then the ``yield`` will now raise :exc:`trio.Cancelled`.
+See :ref:`cancel-yield` for details.

--- a/pytest_trio/_tests/test_fixture_mistakes.py
+++ b/pytest_trio/_tests/test_fixture_mistakes.py
@@ -127,12 +127,14 @@ def test_fixture_cancels_test_but_doesnt_raise(testdir, enable_trio_mode):
         """
         import pytest
         import trio
+        from async_generator import async_generator, yield_
 
         @pytest.fixture
+        @async_generator
         async def async_fixture():
             with trio.CancelScope() as cscope:
                 cscope.cancel()
-                yield
+                await yield_()
 
 
         async def test_whatever(async_fixture):

--- a/pytest_trio/_tests/test_fixture_mistakes.py
+++ b/pytest_trio/_tests/test_fixture_mistakes.py
@@ -143,6 +143,4 @@ def test_fixture_cancels_test_but_doesnt_raise(testdir, enable_trio_mode):
     result = testdir.runpytest()
 
     result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines(
-        ["*async_fixture*cancelled the test*"]
-    )
+    result.stdout.fnmatch_lines(["*async_fixture*cancelled the test*"])

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -328,5 +328,5 @@ def test_complex_cancel_interaction_regression(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(passed=0, failed=1)
     result.stdout.fnmatch_lines_random([
-            "*OOPS*",
+        "*OOPS*",
     ])

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -355,8 +355,7 @@ def _trio_test_runner_factory(item, testfunc=None):
                 test_ctx.error_list.append(
                     RuntimeError(
                         "{} cancelled the test but didn't "
-                        "raise an error"
-                        .format(fixture.name)
+                        "raise an error".format(fixture.name)
                     )
                 )
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     install_requires=[
         "trio >= 0.11",
         "async_generator >= 1.9",
+        "outcome",
         # For node.get_closest_marker
         "pytest >= 3.6"
     ],


### PR DESCRIPTION
- Always report a failure if a fixture cancels the test, even if the
  fixture doesn't then raise an exception
- Inside fixtures, `yield` can now raise `trio.Cancelled`

Closes: #75, #77