### PR TITLE
Fix a few missed .assert_outcomes(errors=)

### DIFF
--- a/pytest_trio/_tests/test_async_fixture.py
+++ b/pytest_trio/_tests/test_async_fixture.py
@@ -139,4 +139,4 @@ def test_raise_in_async_fixture_cause_pytest_error(testdir):
 
     result = testdir.runpytest()
 
-    result.assert_outcomes(error=1)
+    result.assert_outcomes(errors=1)

--- a/pytest_trio/_tests/test_async_yield_fixture.py
+++ b/pytest_trio/_tests/test_async_yield_fixture.py
@@ -259,7 +259,7 @@ def test_async_yield_fixture_with_multiple_yields(
     result = testdir.runpytest()
 
     # TODO: should trigger error instead of failure
-    # result.assert_outcomes(error=1)
+    # result.assert_outcomes(errors=1)
     result.assert_outcomes(failed=1)
 
 

--- a/pytest_trio/_tests/test_basic.py
+++ b/pytest_trio/_tests/test_basic.py
@@ -73,4 +73,4 @@ def test_sync_function_with_trio_mark(testdir):
 
     result = testdir.runpytest()
 
-    result.assert_outcomes(error=1)
+    result.assert_outcomes(errors=1)


### PR DESCRIPTION
Given they are failed not failures, shouldn't these have been erred or errored not errors?  Oh well.

I missed these in #99 because they were `xfail`ed or commented out.