### PR TITLE
Add missing newsfragments for trio_run and py35 removal

### DIFF
--- a/newsfragments/105.feature.rst
+++ b/newsfragments/105.feature.rst
@@ -1,0 +1,1 @@
+Support added for :ref:`alternative Trio run functions <trio-run-config>` via the ``trio_run`` configuration variable and ``@pytest.mark.trio(run=...)``.  Presently supports Trio and QTrio.

--- a/newsfragments/96.removal.rst
+++ b/newsfragments/96.removal.rst
@@ -1,0 +1,1 @@
+Python 3.5 support removed.


### PR DESCRIPTION
So I thought a release would be nice, then I realized there wasn't any news...