### PR TITLE
Bump version and run towncrier for 0.7.0 release

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,21 @@ Release history
 
 .. towncrier release notes start
 
+pytest-trio 0.7.0 (2020-10-15)
+------------------------------
+
+Features
+~~~~~~~~
+
+- Support added for :ref:`alternative Trio run functions <trio-run-config>` via the ``trio_run`` configuration variable and ``@pytest.mark.trio(run=...)``.  Presently supports Trio and QTrio. (`#105 <https://github.com/python-trio/pytest-trio/issues/105>`__)
+
+
+Deprecations and Removals
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Python 3.5 support removed. (`#96 <https://github.com/python-trio/pytest-trio/issues/96>`__)
+
+
 pytest-trio 0.6.0 (2020-05-20)
 ----------------------------------
 

--- a/newsfragments/105.feature.rst
+++ b/newsfragments/105.feature.rst
@@ -1,1 +1,0 @@
-Support added for :ref:`alternative Trio run functions <trio-run-config>` via the ``trio_run`` configuration variable and ``@pytest.mark.trio(run=...)``.  Presently supports Trio and QTrio.

--- a/newsfragments/96.removal.rst
+++ b/newsfragments/96.removal.rst
@@ -1,1 +1,0 @@
-Python 3.5 support removed.

--- a/pytest_trio/_version.py
+++ b/pytest_trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.6.0+dev"
+__version__ = "0.7.0"

--- a/pytest_trio/_version.py
+++ b/pytest_trio/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.7.0"
+__version__ = "0.7.0+dev"


### PR DESCRIPTION
Draft for:
- [x] Actually release to https://pypi.org/project/pytest-trio/
- [x] Add back `+dev`