### PR TITLE
Remove trio.tests import causing warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ nitpick_ignore = [
     ("py:obj", "bytes-like"),
 ]
 
+
 # XX hack the RTD theme until
 #   https://github.com/rtfd/sphinx_rtd_theme/pull/382
 # is shipped (should be in the release after 0.2.4)

--- a/pytest_trio/_tests/test_async_fixture.py
+++ b/pytest_trio/_tests/test_async_fixture.py
@@ -2,7 +2,6 @@ import pytest
 
 
 def test_single_async_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -25,7 +24,6 @@ def test_single_async_fixture(testdir):
 
 
 def test_async_fixture_recomputed_for_each_test(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -56,7 +54,6 @@ def test_async_fixture_recomputed_for_each_test(testdir):
 
 
 def test_nested_async_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -89,7 +86,6 @@ def test_nested_async_fixture(testdir):
 
 
 def test_async_within_sync_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -122,7 +118,6 @@ def test_async_within_sync_fixture(testdir):
 # async fixture...
 @pytest.mark.xfail(reason="Not implemented yet")
 def test_raise_in_async_fixture_cause_pytest_error(testdir):
-
     testdir.makepyfile(
         """
         import pytest

--- a/pytest_trio/_tests/test_async_yield_fixture.py
+++ b/pytest_trio/_tests/test_async_yield_fixture.py
@@ -38,7 +38,6 @@ def test_single_async_yield_fixture(testdir):
 
 
 def test_nested_async_yield_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -93,7 +92,6 @@ def test_nested_async_yield_fixture(testdir):
 
 
 def test_async_yield_fixture_within_sync_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -139,7 +137,6 @@ def test_async_yield_fixture_within_sync_fixture(testdir):
 
 
 def test_async_yield_fixture_within_sync_yield_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -190,7 +187,6 @@ def test_async_yield_fixture_within_sync_yield_fixture(testdir):
 
 
 def test_async_yield_fixture_with_multiple_yields(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -217,7 +213,6 @@ def test_async_yield_fixture_with_multiple_yields(testdir):
 
 
 def test_async_yield_fixture_with_nursery(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -253,7 +248,6 @@ def test_async_yield_fixture_with_nursery(testdir):
 
 
 def test_async_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
-
     testdir.makepyfile(
         """
         import pytest

--- a/pytest_trio/_tests/test_basic.py
+++ b/pytest_trio/_tests/test_basic.py
@@ -2,7 +2,6 @@ import pytest
 
 
 def test_async_test_is_executed(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -27,7 +26,6 @@ def test_async_test_is_executed(testdir):
 
 
 def test_async_test_as_class_method(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -60,7 +58,6 @@ def test_async_test_as_class_method(testdir):
 
 @pytest.mark.xfail(reason="Raises pytest internal error so far...")
 def test_sync_function_with_trio_mark(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -77,7 +74,6 @@ def test_sync_function_with_trio_mark(testdir):
 
 
 def test_skip_and_xfail(testdir):
-
     testdir.makepyfile(
         """
         import functools

--- a/pytest_trio/_tests/test_hypothesis_interaction.py
+++ b/pytest_trio/_tests/test_hypothesis_interaction.py
@@ -1,10 +1,5 @@
 import pytest
 import trio
-from trio.tests.test_scheduler_determinism import (
-    scheduler_trace,
-    test_the_trio_scheduler_is_not_deterministic,
-    test_the_trio_scheduler_is_deterministic_if_seeded,
-)
 from hypothesis import given, settings, strategies as st
 
 from pytest_trio.plugin import _trio_test_runner_factory
@@ -36,6 +31,22 @@ async def test_mark_outer(n):
 async def test_mark_and_parametrize(x, y):
     assert x is None
     assert y in (1, 2)
+
+
+async def scheduler_trace():
+    """Returns a scheduler-dependent value we can use to check determinism."""
+    trace = []
+
+    async def tracer(name):
+        for i in range(10):
+            trace.append((name, i))
+            await trio.sleep(0)
+
+    async with trio.open_nursery() as nursery:
+        for i in range(5):
+            nursery.start_soon(tracer, i)
+
+    return tuple(trace)
 
 
 def test_the_trio_scheduler_is_deterministic_under_hypothesis():

--- a/pytest_trio/_tests/test_sync_fixture.py
+++ b/pytest_trio/_tests/test_sync_fixture.py
@@ -12,7 +12,6 @@ async def test_single_sync_fixture(sync_fix):
 
 
 def test_single_yield_fixture(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -47,7 +46,6 @@ def test_single_yield_fixture(testdir):
 
 
 def test_single_yield_fixture_with_async_deps(testdir):
-
     testdir.makepyfile(
         """
         import pytest
@@ -90,7 +88,6 @@ def test_single_yield_fixture_with_async_deps(testdir):
 
 
 def test_sync_yield_fixture_crashed_teardown_allow_other_teardowns(testdir):
-
     testdir.makepyfile(
         """
         import pytest


### PR DESCRIPTION
It is deprecated and the replacement is made private as trio._tests. While we could be using that, this commit copies over the one relevant function that is actually necessary. The other two imports just repeat tests that are already in trio and do not need repeating here.