### PR TITLE
synchronous fixture setup and teardown 

### DIFF
--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -75,6 +75,7 @@ def test_fixture_basic_ordering(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
 
+
 def test_contextvars_modification_follows_fixture_ordering(testdir):
     """
     Tests that fixtures are being set up and tore down synchronously.
@@ -88,7 +89,6 @@ def test_contextvars_modification_follows_fixture_ordering(testdir):
     testdir.makepyfile(
         """
         import pytest
-        from pytest_trio import trio_fixture
         import trio_asyncio
         import asyncio
         import trio

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -75,7 +75,7 @@ def test_fixture_basic_ordering(testdir):
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
 
-def test_context_vars_modification_follows_fixture_ordering(testdir):
+def test_contextvars_modification_follows_fixture_ordering(testdir):
     """
     Tests that fixtures are being set up and tore down synchronously.
     

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -1,12 +1,14 @@
 import pytest
 
 
-# Tests that:
-# - leaf_fix gets set up first and torn down last
-# - the two fix_{1,2} fixtures run their setup/teardown code
-#   in the expected order
-#   fix_1 setup -> fix_2 setup -> fix_2 teardown -> fix_1 teardown
 def test_fixture_basic_ordering(testdir):
+    """
+    Tests that:
+    - leaf_fix gets set up first and torn down last
+    - the two fix_{1,2} fixtures run their setup/teardown code
+      in the expected order
+      fix_1 setup -> fix_2 setup -> fix_2 teardown -> fix_1 teardown
+    """
     testdir.makepyfile(
         """
         import pytest
@@ -76,10 +78,11 @@ def test_fixture_basic_ordering(testdir):
     result.assert_outcomes(passed=1)
 
 
-# This test involves several fixtures forming
-# a pretty complicated dag, make sure we got the topological
-# sort in order
 def test_fixture_complicated_dag_ordering(testdir):
+    """
+    This test involves several fixtures forming a pretty
+    complicated dag, make sure we got the topological sort in order
+    """
     testdir.makepyfile(
         """
         import pytest
@@ -256,6 +259,10 @@ def test_nursery_fixture_teardown_ordering(testdir):
 
 
 def test_error_message_upon_circular_dependency(testdir):
+    """
+    Make sure that the error message is produced if there's
+    a circular dependency on the fixtures
+    """
     testdir.makepyfile(
         """
         import pytest
@@ -295,8 +302,8 @@ def test_error_collection(testdir):
     # sure that all the fixtures have started before any of them start
     # crashing.
 
-    # Although all fixtures are meant to crash, we only expect the first crash output
-    # since the teardown are synchronous.
+    # Although all fixtures are meant to crash, we only expect the crash output
+    # of the first fixture in the teardown sequence since the teardown are synchronous.
     testdir.makepyfile(
         """
         import pytest

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -357,11 +357,7 @@ def test_error_collection(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(passed=1, failed=1)
-    result.stdout.fnmatch_lines_random(
-        [
-            "*CRASH_NONGEN*",
-        ]
-    )
+    result.stdout.fnmatch_lines(["*CRASH_NONGEN*"])
 
 
 @pytest.mark.parametrize("bgmode", ["nursery fixture", "manual nursery"])

--- a/pytest_trio/_tests/test_fixture_ordering.py
+++ b/pytest_trio/_tests/test_fixture_ordering.py
@@ -4,7 +4,7 @@ import pytest
 # Tests that:
 # - leaf_fix gets set up first and torn down last
 # - the two fix_{1,2} fixtures run their setup/teardown code
-#   in the expected order 
+#   in the expected order
 #   fix_1 setup -> fix_2 setup -> fix_2 teardown -> fix_1 teardown
 def test_fixture_basic_ordering(testdir):
     testdir.makepyfile(
@@ -78,7 +78,7 @@ def test_fixture_basic_ordering(testdir):
 def test_contextvars_modification_follows_fixture_ordering(testdir):
     """
     Tests that fixtures are being set up and tore down synchronously.
-    
+
     Specifically this ensures that fixtures that modify context variables
     doesn't lead to a weird contextvar states
 
@@ -90,16 +90,16 @@ def test_contextvars_modification_follows_fixture_ordering(testdir):
         import pytest
         from pytest_trio import trio_fixture
         import trio_asyncio
-        import asyncio 
+        import asyncio
         import trio
         class Resource():
             async def __aenter__(self):
-                await trio_asyncio.aio_as_trio(asyncio.sleep(0)) 
-            
+                await trio_asyncio.aio_as_trio(asyncio.sleep(0))
+
             async def __aexit__(self, *_):
                 # We need to yield and run another trio task
                 await trio.sleep(0.1)
-                await trio_asyncio.aio_as_trio(asyncio.sleep(0)) 
+                await trio_asyncio.aio_as_trio(asyncio.sleep(0))
 
         @pytest.fixture
         async def resource():
@@ -121,6 +121,7 @@ def test_contextvars_modification_follows_fixture_ordering(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
 
 def test_nursery_fixture_teardown_ordering(testdir):
     testdir.makepyfile(
@@ -188,7 +189,7 @@ def test_error_collection(testdir):
     # crashing.
 
     # Although all fixtures are meant to crash, we only expect the first crash output
-    # since the teardown are synchronous. 
+    # since the teardown are synchronous.
     testdir.makepyfile(
         """
         import pytest

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -162,9 +162,11 @@ class TrioFixture:
         self._pytest_kwargs = pytest_kwargs
         self._is_test = is_test
         # Previous and next fixture in terms of fixture topological order
-        # During set up, each fixture waits for previous_fixture to set its setup_done value 
+        # During set up, each fixture waits for
+        # its previous_fixture to set its setup_done value
         self.previous_fixture = None
-        # During tear down, each fixture waits for next_fixture to set its teardown_done value 
+        # During tear down, each fixture waits for
+        # itsnext_fixture to set its teardown_done value
         self.next_fixture = None
         # These attrs are all accessed from other objects:
         # Downstream users read this value.
@@ -183,14 +185,14 @@ class TrioFixture:
         deps = []
         for value in self._pytest_kwargs.values():
             if isinstance(value, TrioFixture):
-                for indirect_dependency in value.collect_dependencies():
-                    if indirect_dependency not in deps:
-                        deps.append(indirect_dependency)
+                for dependency in value.collect_dependencies():
+                    if dependency not in deps:
+                        deps.append(dependency)
         deps.append(self)
         return deps
-    
+
     def collect_register_dependencies(self):
-        # Collect dependencies then register previous and next fixture 
+        # Collect dependencies then register previous and next fixture
         # for each fixture (in terms of its topological order)
         deps = self.collect_dependencies()
         for index, dep in enumerate(deps):
@@ -198,7 +200,7 @@ class TrioFixture:
                 dep.previous_fixture = deps[index - 1]
             if index < len(deps) - 1:
                 dep.next_fixture = deps[index + 1]
-        return deps 
+        return deps
 
     @asynccontextmanager
     async def _fixture_manager(self, test_ctx):
@@ -235,7 +237,7 @@ class TrioFixture:
         async with self._fixture_manager(test_ctx) as nursery_fixture:
             if self.previous_fixture:
                 await self.previous_fixture.setup_done.wait()
-            
+
             # Resolve our kwargs
             resolved_kwargs = {}
             for name, value in self._pytest_kwargs.items():
@@ -317,7 +319,7 @@ class TrioFixture:
                 with trio.CancelScope(shield=True):
                     if self.next_fixture:
                         await self.next_fixture.teardown_done.wait()
-            
+
             # Do our teardown
             if isasyncgen(func_value):
                 try:


### PR DESCRIPTION
Mainly fixes #137, by making fixtures setup and teardown synchronous 
Related issues and discussions:
- #57. 
  - It looks like we had figured some pitfalls with the concurrent version but we've been able to work around it so far.
- #59 
   - If the fixtures setup are synchronous, it should be easier to implement the separate `Context` approach

**Implementation details**
- I created a topological sort of all fixture dependencies for each test, and set them up synchronously, and then tear them down synchronously in a reverse order, by waiting for the 'previous' or 'next' fixture in the topology
   - njsmith mentioned [here](https://github.com/python-trio/pytest-trio/pull/50#issuecomment-414652134) that we can record the order of fixture construction from pytest - but I'm not sure if this is necessary? I was thinking we can create our own order, as long as it respects the dependency order, but I might be missing something, so let me know if this ordering is not enough to cover all cases!
- I added a test that tests for the `contextvar` not intertwining with each other
  - I also verified that this fails flakily without this diff.

**Concerns**
- This change might impact user experience, especially users that sets up i/o heavy fixtures. 

This is my first PR, want to double check if I've done the complete checklist
- I installed pre-commit with config file in the [trio repo](https://github.com/python-trio/trio/blob/master/.pre-commit-config.yaml) since there doesn't seem to be one in this repo. 
  - I ended up getting warning for `asend` from `codespell`, so I just disabled `codespell` and committed without the `codespell` check
- I ran pytest with `PYTHONPATH="pytest-trio" pytest pytest-trio` and I received 2 xfailed, and 1 warning. 
  - I think the 2 xfailed are expected, since these 2 are indeed marked as xfail
  - I can also see the warning when running pytest without setting the `PYTHONPATH`

Let me know if I'm missing anything, would appreciate any feedback :D 