### PR TITLE
GitHub Actions: Add Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python }}'
+        uses: actions/setup-python@v6
         with:
           python-version: '${{ matrix.python }}'
+          allow-prereleases: true
       - name: Run tests
         run: ./ci.sh
         shell: bash
@@ -35,30 +36,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['pypy-3.8', '3.8', 'pypy-3.9', '3.9', 'pypy-3.10', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
         check_formatting: ['0']
         check_docs: ['0']
         extra_name: ['']
         include:
-          - python: '3.9'
+          - python: '3.x'
             check_formatting: '1'
             extra_name: ', check formatting'
-          - python: '3.9'
+          - python: '3.12'  # sphinx-build: cgi module was removed in 3.13
             check_docs: '1'
             extra_name: ', check docs'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        if: "!endsWith(matrix.python, '-dev')"
+        uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v6
         with:
           python-version: '${{ matrix.python }}'
-      - name: Setup python (dev)
-        uses: deadsnakes/action@v2.0.2
-        if: endsWith(matrix.python, '-dev')
-        with:
-          python-version: '${{ matrix.python }}'
+          allow-prereleases: true
       - name: Run tests
         run: ./ci.sh
         env:
@@ -74,14 +70,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v6
         with:
           python-version: '${{ matrix.python }}'
+          allow-prereleases: true
       - name: Run tests
         run: ./ci.sh
         env:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"  # sphinx-build: cgi module was removed in 3.13
 
 formats:
   - htmlzip
@@ -15,4 +15,5 @@ python:
     - requirements: docs-requirements.txt
 
 sphinx:
+  configuration: docs/source/conf.py
   fail_on_warning: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,18 @@ authors = [
 description = "Pytest plugin for trio"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases
* https://pypy.org/download.html -- PyPy only keeps a single release as current.

Note: Python 3.8 was EOL one year ago.  Python 3.9 will EOL in 10 days, when Python 3.14 will be released.