### PR TITLE
GitHub Actions :Lint Python code with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: astral-sh/ruff-action@v3
+
   Windows:
     name: 'Windows (${{ matrix.python }})'
     runs-on: 'windows-latest'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,7 +101,7 @@ author = "The pytest-trio authors"
 # built documents.
 #
 # The short X.Y version.
-import pytest_trio
+import pytest_trio  # noqa: E402
 
 version = pytest_trio.__version__
 # The full version, including alpha/beta/rc tags.
@@ -143,7 +143,7 @@ suppress_warnings = ["epub.unknown_project_files"]
 # We have to set this ourselves, not only because it's useful for local
 # testing, but also because if we don't then RTD will throw away our
 # html_theme_options.
-import sphinx_rtd_theme
+import sphinx_rtd_theme  # noqa: E402
 
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,14 @@ partial_branches = [
     "if .* or not _t.TYPE_CHECKING:",
     "if .* or not t.TYPE_CHECKING:",
 ]
+
+[tool.ruff]
+lint.extend-select = [
+    "ASYNC",  # flake8-async
+    "C4",     # flake8-comprehensions
+    "PERF",   # Perflint
+    "PT",     # flake8-pytest-style
+]
+lint.ignore = [
+    "ASYNC115",  # `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`
+]

--- a/pytest_trio/__init__.py
+++ b/pytest_trio/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for pytest-trio."""
 
-from ._version import __version__
+from ._version import __version__  # noqa: F401
 from .plugin import trio_fixture
 
 __all__ = ["trio_fixture"]

--- a/pytest_trio/_tests/test_fixture_mistakes.py
+++ b/pytest_trio/_tests/test_fixture_mistakes.py
@@ -1,5 +1,5 @@
-import pytest
-from pytest_trio import trio_fixture
+import pytest  # noqa: F401
+from pytest_trio import trio_fixture  # noqa: F401
 
 from .helpers import enable_trio_mode
 

--- a/pytest_trio/_tests/test_trio_mode.py
+++ b/pytest_trio/_tests/test_trio_mode.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # noqa: F401
 
 from .helpers import enable_trio_mode
 
@@ -139,7 +139,7 @@ def test_invalid_trio_run_fails(testdir):
 
 
 def test_closest_explicit_run_wins(testdir):
-    testdir.makefile(".ini", pytest=f"[pytest]\ntrio_mode = true\ntrio_run = trio\n")
+    testdir.makefile(".ini", pytest="[pytest]\ntrio_mode = true\ntrio_run = trio\n")
     testdir.makepyfile(qtrio=qtrio_text)
 
     test_text = """
@@ -159,7 +159,7 @@ def test_closest_explicit_run_wins(testdir):
 
 
 def test_ini_run_wins_with_blank_marker(testdir):
-    testdir.makefile(".ini", pytest=f"[pytest]\ntrio_mode = true\ntrio_run = qtrio\n")
+    testdir.makefile(".ini", pytest="[pytest]\ntrio_mode = true\ntrio_run = qtrio\n")
     testdir.makepyfile(qtrio=qtrio_text)
 
     test_text = """

--- a/pytest_trio/plugin.py
+++ b/pytest_trio/plugin.py
@@ -283,7 +283,7 @@ class TrioFixture:
                 for event in self.user_done_events:
                     await event.wait()
             except BaseException as exc:
-                assert isinstance(exc, trio.Cancelled)
+                assert isinstance(exc, trio.Cancelled)  # noqa: PT017
                 yield_outcome = outcome.Error(exc)
                 test_ctx.crash(self, None)
                 with trio.CancelScope(shield=True):


### PR DESCRIPTION
* https://docs.astral.sh/ruff
    * https://github.com/astral-sh/ruff-action

% `ruff rule ASYNC115`
# async-zero-sleep (ASYNC115)

Derived from the **flake8-async** linter.

Fix is always available.

## What it does
Checks for uses of `trio.sleep(0)` or `anyio.sleep(0)`.

## Why is this bad?
`trio.sleep(0)` is equivalent to calling `trio.lowlevel.checkpoint()`.
However, the latter better conveys the intent of the code.

## Example
```python
import trio


async def func():
    await trio.sleep(0)
```

Use instead:
```python
import trio


async def func():
    await trio.lowlevel.checkpoint()
```
## Fix safety
This rule's fix is marked as unsafe if there's comments in the
`trio.sleep(0)` expression, as comments may be removed.

For example, the fix would be marked as unsafe in the following case:
```python
import trio


async def func():
    await trio.sleep(  # comment
        # comment
        0
    )
```