### PR TITLE
GitHub Actions: Add free threaded Python 3.14t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy-3.11']
         check_formatting: ['0']
         check_docs: ['0']
         extra_name: ['']
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Added Python 3.14t to the CI workflow for Windows, Ubuntu, and macOS.